### PR TITLE
fix several issues with getWhereParams

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -248,14 +248,15 @@ const interpolate = _.curry((db, sql, params) => {
 const getWhereParams = _.curry(
   (db, table, params, project = '*', no_cache = false) => {
 
-    const select = `SELECT \`${project}\` FROM \`${table}\` WHERE 1 `;
+    const select_clause = `SELECT ${project} FROM \`${table}\` WHERE 1 `;
     const where = _.compose(
-      _.join(' ')
+      _.join('')
     , _.map((key) => ` AND ${key} = :${key} `)
     , _.keys
     )(params);
 
-    const sql = interpolate(db, select + where, params);
+
+    const sql = interpolate(db, select_clause + where, params);
 
     return select(db, sql, params, no_cache);
   

--- a/test/lib/query.spec.js
+++ b/test/lib/query.spec.js
@@ -191,4 +191,38 @@ describe('Pimp My Sql :: Query', function() {
 
   });
 
+
+  describe('::getWhereParams', function() {
+
+
+    it('should assemble a query from the given options', () => {
+
+      const table      = 'test';
+      const projection = 'foo AS bar';
+      const params     = {
+        bar: 'baz'
+      , boo: 'bah'
+      };
+
+      testLib.query = sinon.stub().yields(null, [ { foo: 42 } ]);
+      testLib.escape = (x) => `'${x}'`;
+
+      const sql_string = `SELECT foo AS bar FROM \`test\` WHERE 1 `
+                       + ` AND bar = 'baz' `
+                       + ` AND boo = 'bah' `
+
+      return Query.getWhereParams(testLib, table, params, projection)
+
+      .then((result) => {
+
+        expect(result[0].foo).to.eql(42)
+        expect(testLib.query.calledOnce).to.be.true
+        expect(testLib.query.calledWith(sql_string, params)).to.be.true
+
+      });
+
+    });
+
+  });
+
 });


### PR DESCRIPTION
1. Rename `select` variable to `select_clause` to prevent the internal
override of the `select` function.
2. Remove bad escaping from the projection
3. join with an empty string instead of a space.