### PR TITLE
Model Search

### DIFF
--- a/lib/factory-model.js
+++ b/lib/factory-model.js
@@ -17,6 +17,7 @@ const ModelFactory = ({ table, sql, intercepts = {} }) => {
   , deactivate         : Model.deactivate(intercepts, sql_factory)
   , softDelete         : Model.softDelete(intercepts, sql_factory)
   , save               : Model.save(intercepts, sql_factory)
+  , search             : Model.search(sql_factory)
   };
 
 };

--- a/lib/model.js
+++ b/lib/model.js
@@ -2,6 +2,7 @@
 const R          = require('ramda');
 const Bluebird   = require('bluebird');
 const query      = require('./query');
+const Search     = require('./search');
 
 const NO_CACHE = 1;
 
@@ -166,6 +167,25 @@ const save = R.curry(
   }
 );
 
+const search = R.curry((sql_factory, map, conn, params) => {
+
+  const _params = Search.parseParams(map)(params)
+
+  const clauses = Search.getClauses(map, _params)
+
+  let sql = sql_factory(clauses)
+  sql = query.interpolate(conn)(sql)(_params)
+
+  const sql_paginated = R.concat(sql, clauses.limit)
+  const sql_count = Search.getCountSql(sql)
+
+  return Bluebird.props({
+    params: _params,
+    count : query.select(conn, sql_count, [], false).get(0).get('count'),
+    rows  : query.select(conn, sql_paginated, [], false)
+  })
+
+})
 
 module.exports = {
   getById
@@ -178,4 +198,5 @@ module.exports = {
 , deactivate
 , softDelete
 , save
+, search
 }

--- a/lib/model.js
+++ b/lib/model.js
@@ -176,7 +176,7 @@ const search = R.curry((sql_factory, map, conn, params) => {
   let sql = sql_factory(clauses)
   sql = query.interpolate(conn)(sql)(_params)
 
-  const sql_paginated = R.concat(sql, clauses.limit)
+  const sql_paginated = Search.addPagination(conn, sql, _params)
   const sql_count = Search.getCountSql(sql)
 
   return Bluebird.props({

--- a/lib/search.js
+++ b/lib/search.js
@@ -45,7 +45,12 @@ _sanitizeParams = R.pickBy(R.compose(R.not,R.isNil))
 // _normalizeParams:: Object -> Object - Object
 _normalizeParams = (map) => R.mapObjIndexed(
   (val, key) => {
-    const _normalize = R.pathOr(R.identity, [ key, 'normalize'], map);
+
+    let _normalize = R.identity
+
+    if(typeof(map[key]) == 'function')
+      _normalize = R.propOr(_normalize, 'normalize', map[key](val))
+
     return _normalize(val)
   }
 )
@@ -95,7 +100,7 @@ const getClauses = (map, params) => {
     R.without(['page','limit'])
   )(params)
 
-  const _resolve = (arg) => (fn) => {return fn(arg)}
+  const _resolveClause = (params) => (fn, key) => {return fn(params[key])}
 
   const _mergeClauses = (aggregate, clauses) => {
     const _clauses = R.pick(CLAUSES, clauses)
@@ -106,7 +111,7 @@ const getClauses = (map, params) => {
     _sanitizeJoins,
     R.reduce(_mergeClauses, {}),
     R.values,
-    R.mapObjIndexed(_resolve(params)),
+    R.mapObjIndexed(_resolveClause(params)),
     R.pick(_keys)
   )(map)
 }

--- a/lib/search.js
+++ b/lib/search.js
@@ -1,0 +1,183 @@
+const R = require('ramda')
+const Query = require('./query.js')
+
+const PAGINATION_PARAMS = [
+  'page',
+  'limit'
+]
+
+const DEFAULT_PAGINATION_PARAMS = {
+  page: 1,
+  limit: 16
+}
+
+const PAGINATION_LIMIT_CLAUSE = ' LIMIT :offset, :limit'
+
+const REGEX_JOIN = /((?:LEFT|RIGHT|INNER|OUTER|CROSS)? ?JOIN +`?(.+?)`? *(?: +AS +`?(.+?)`?)? +ON .+?) ?(?=LEFT|RIGHT|INNER|OUTER|CROSS|JOIN|\n|$)/i
+
+const CLAUSES = [
+  'select',
+  'join',
+  'where',
+  'order'
+]
+
+const CLAUSE_DELIMITER = {
+  select: ', '
+}
+
+// parseParams:: Object -> Object -> Object
+parseParams = (map) => R.compose(
+  R.converge(
+    R.merge,
+    [
+      _parseSearchParams(map),
+      _parsePaginationParams
+    ]
+  ),
+  _normalizeParams(map),
+  _sanitizeParams
+)
+
+// _sanitizeParamss:: Object -> Object
+_sanitizeParams = R.pickBy(R.compose(R.not,R.isNil))
+
+// _normalizeParams:: Object -> Object - Object
+_normalizeParams = (map) => R.mapObjIndexed(
+  (val, key) => {
+    const _normalize = R.pathOr(R.identity, [ key, 'normalize'], map);
+    return _normalize(val)
+  }
+)
+
+
+// _parseSearchParams:: Object -> Object -> Object
+_parseSearchParams = (map) => R.compose(
+  R.pick(R.keys(map)),
+  R.without(PAGINATION_PARAMS)
+)
+
+
+// _parsePaginationParams:: Object -> Object
+_parsePaginationParams = R.compose(
+  (params) => ({
+    offset: (parseInt(params.page) - 1) * parseInt(params.limit),
+    limit : parseInt(params.limit),
+    page : parseInt(params.page)
+  }),
+  R.pick(PAGINATION_PARAMS),
+  R.merge(DEFAULT_PAGINATION_PARAMS)
+)
+
+
+// addPagination:: MySqlConnection, String, Object -> String
+addPagination = R.curry((db, sql, params) => {
+  return R.compose(
+    R.concat(sql),
+    Query.interpolate(db)(PAGINATION_LIMIT_CLAUSE)
+  )(params)
+})
+
+
+// concatClause:: String, String, String -> String
+const _concatClause = (key, left, right) => {
+
+  const delimiter = R.defaultTo(' ', CLAUSE_DELIMITER[key])
+
+  return R.join(delimiter, [left, right])
+}
+
+// getClauses:: Object -> Object -> Object
+const getClauses = (map, params) => {
+
+  const _keys = R.compose(
+    R.keys,
+    R.without(['page','limit'])
+  )(params)
+
+  const _resolve = (arg) => (fn) => {return fn(arg)}
+
+  const _mergeClauses = (aggregate, clauses) => {
+    const _clauses = R.pick(CLAUSES, clauses)
+    return R.mergeWithKey(_concatClause, aggregate, _clauses)
+  }
+
+  return R.compose(
+    _sanitizeJoins,
+    R.reduce(_mergeClauses, {}),
+    R.values,
+    R.mapObjIndexed(_resolve(params)),
+    R.pick(_keys)
+  )(map)
+}
+
+
+// getCountSql:: String -> String
+const getCountSql = (sql) => {
+  return `
+    SELECT COUNT(*) AS \`count\`
+    FROM (${ sql }) AS \`temp\`
+`
+}
+
+
+// _getJoins:: String -> Array
+const _getJoins = (input) => {
+
+  let matches, output = []
+
+  let index = 0
+
+  matches = REGEX_JOIN.exec(input)
+
+  while(matches) {
+    var [match, table, alias] = matches
+
+    output.push({
+      alias: R.defaultTo(table, alias),
+      match: match,
+      index: matches.index + index
+    })
+
+    input = R.slice(matches.index+match.length, Infinity, matches.input)
+    index += matches.index+match.length
+
+    matches = REGEX_JOIN.exec(input)
+  }
+
+  return output
+
+}
+
+
+// _sanitizeJoins:: String -> Array -> String
+const _sanitizeJoins = (clauses) => {
+
+  let join_clause = clauses.join
+
+  let joins = _getJoins(join_clause)
+
+  if(R.isNil(join_clause))
+    return ''
+
+  return R.compose(
+    R.merge(clauses),
+    R.objOf('join'),
+    R.reduce((c,n) => {
+      return R.join('', R.remove(n.index, n.match.length, c))
+    }, join_clause),
+    R.sortBy(R.compose(R.negate, R.prop('index'))),
+    R.flatten,
+    R.map(R.tail),
+    R.values,
+    R.groupBy(R.prop('alias'))
+  )(joins)
+
+}
+
+module.exports = {
+  parseParams: parseParams,
+  addPagination: addPagination,
+  getClauses: getClauses,
+  getCountSql: getCountSql
+}

--- a/test/index/model.spec.js
+++ b/test/index/model.spec.js
@@ -137,7 +137,11 @@ const sqlGetById =
 
     it('should return no results', (done) => {
 
-      const params = {}
+      const params = {
+        page: undefined,
+        limit: undefined,
+        starts_with: undefined
+      }
 
       const db = {
         escape: R.identity,

--- a/test/index/model.spec.js
+++ b/test/index/model.spec.js
@@ -132,21 +132,7 @@ const sqlGetById =
     const map = {
       starts_with: () => ({
         join: 'JOIN `rah` ON `rag`.`id` = `foo`.`rah_id`'
-      }),
-
-      verified: () => ({
-        where: '`verified` = :verified'
-      }),
-
-      order_by: (params) => {
-        const param = params['order_by']
-        if(R.equals(param, 'date'))
-          return {
-            order: 'ORDER BY `date`'
-          }
-        else
-          return {}
-      }
+      })
     }
 
     it('should return no results', (done) => {

--- a/test/index/model.spec.js
+++ b/test/index/model.spec.js
@@ -1,7 +1,9 @@
 /*eslint-env node, mocha*/
-const { expect } = require('chai');
+const { expect, assert } = require('chai');
 const sinon      = require('sinon');
 const { Model }  = require('../../index');
+const Bluebird   = require('bluebird');
+const R          = require('ramda');
 
 describe('Pimp-My-Sql Model', function() {
 
@@ -124,5 +126,104 @@ const sqlGetById =
     });
 
   });
+
+  describe('::search', function() {
+
+    const map = {
+      starts_with: () => ({
+        join: 'JOIN `rah` ON `rag`.`id` = `foo`.`rah_id`'
+      }),
+
+      verified: () => ({
+        where: '`verified` = :verified'
+      }),
+
+      order_by: (params) => {
+        const param = params['order_by']
+        if(R.equals(param, 'date'))
+          return {
+            order: 'ORDER BY `date`'
+          }
+        else
+          return {}
+      }
+    }
+
+    it('should return no results', (done) => {
+
+      const params = {}
+
+      const db = {
+        escape: R.identity,
+        query : (sql, params, callback) => {
+          if(sql.indexOf(' `temp`') == -1)
+            return callback(null, [])
+          else
+            return callback(null, [{count: 0}])
+        }
+      }
+
+      const expected = {
+        params: {
+          limit: 16,
+          offset: 0,
+          page: 1
+        },
+        rows: [],
+        count: 0
+      }
+
+      TestModel.search(map, db, params)
+      .then((results) => {
+        expect(results).to.eql(expected)
+        done()
+      })
+      .catch(done)
+
+    })
+
+    it('should generate search results', (done) => {
+
+      params = {
+        starts_with: 'asdf',
+        ends_with: 'fdsa'
+      }
+
+      query_results = [
+        {id: 1},
+        {id: 2},
+        {id: 3}
+      ]
+
+      db = {
+        escape: R.identity,
+        query : (sql, params, callback) => {
+          if(sql.indexOf(' `temp`') == -1)
+            return callback(null, query_results)
+          else
+            return callback(null, [{count: query_results.length}])
+        }
+      }
+
+      const expected = {
+        params: {
+          limit: 16,
+          offset: 0,
+          page: 1,
+          starts_with: 'asdf'
+        },
+        rows: query_results,
+        count: query_results.length
+      }
+
+      TestModel.search(map, db, params)
+        .then((results) => {
+          expect(results).to.eql(expected)
+          done()
+        })
+        .catch(done)
+    })
+
+  })
 
 });

--- a/test/lib/search.spec.js
+++ b/test/lib/search.spec.js
@@ -1,0 +1,289 @@
+const R           = require('ramda');
+const { expect }  = require('chai');
+const { inspect } = require('util');
+const sinon       = require('sinon');
+const Search = require('../../lib/search.js')
+
+
+describe('lib/search.js', () => {
+
+  describe('::parseParams', () => {
+
+    it('should return default pagination params', (done) => {
+
+      const test = {}
+
+      const results = Search.parseParams({})(test)
+
+      const expected = {
+        offset: 0,
+        limit: 16,
+        page: 1
+      }
+
+      expect(results).to.eql(expected)
+
+      done()
+
+    })
+
+    it('should return offset of 24', (done) => {
+
+      const test = {
+        page: 3,
+        limit: 12
+      }
+
+      const results = Search.parseParams({})(test)
+
+      const expected = {
+        offset: 24,
+        limit: 12,
+        page: 3
+      }
+
+      expect(results).to.eql(expected)
+
+      done()
+
+    })
+
+    it('should not return starts_with param', (done) => {
+
+      const test = {
+        starts_with: 'asdf'
+      }
+
+      const map = {}
+
+      const results = Search.parseParams(map)(test)
+
+      const expected = {
+        offset: 0,
+        limit: 16,
+        page: 1
+      }
+
+      expect(results).to.eql(expected)
+
+      done()
+
+    })
+
+    it('should return starts_with param', (done) => {
+
+      const test = {
+        starts_with: 'asdf'
+      }
+
+      const map = {
+        starts_with: {
+          validation: []
+        }
+      }
+
+      const results = Search.parseParams(map)(test)
+
+      const expected = {
+        offset: 0,
+        limit: 16,
+        page: 1,
+        starts_with: 'asdf'
+      }
+
+      expect(results).to.eql(expected)
+
+      done()
+
+    })
+
+    it('should return with normalized starts_with param', (done) => {
+
+      const test = {
+        starts_with: 'asdf'
+      }
+
+      const map = {
+        starts_with: {
+          validation: [],
+          normalize: R.toUpper
+        }
+      }
+
+      const results = Search.parseParams(map)(test)
+
+      const expected = {
+        offset: 0,
+        limit: 16,
+        page: 1,
+        starts_with: 'ASDF'
+      }
+
+      expect(results).to.eql(expected)
+
+      done()
+
+    })
+
+  })
+
+
+  describe('::addPagination', (done) => {
+
+    it('should interpolate limit clause', (done) => {
+
+      db = {
+        escape: R.identity
+      }
+
+      params = {
+        offset: 24,
+        limit: 12,
+        page: 1
+      }
+
+      expected = 'QUERY LIMIT 24, 12'
+
+      const results = Search.addPagination(db, 'QUERY', params)
+
+      expect(results).to.eql(expected)
+
+      done()
+    })
+
+  })
+
+
+  describe('::getClauses', (done) => {
+
+    it('should return clauses', (done) => {
+
+      const map = {
+        starts_with: () => ({
+          normalize: R.identity,
+          select: '`starts` FROM `start`',
+          join: 'JOIN `start` ON `start`.`id` IS NOT NULL',
+          where: ' AND `start`.`deleted` IS NULL'
+        }),
+        ends_with: () => ({
+          normalize: R.identity,
+          select: '`ends` FROM `ending`',
+          join: 'JOIN `ending` ON `ending`.`id` IS NOT NULL',
+          where: ' AND `ending`.`deleted` IS NULL'
+        })
+      }
+
+      const params = {
+        'starts_with': 'asdf'
+      }
+
+      const expected = {
+        select: '`starts` FROM `start`',
+        join: 'JOIN `start` ON `start`.`id` IS NOT NULL',
+        where: ' AND `start`.`deleted` IS NULL'
+      }
+
+      const results = Search.getClauses(map, params)
+
+      expect(results).to.eql(expected)
+
+      done()
+
+    })
+
+    it('should merge clauses', (done) => {
+
+      const map = {
+        starts_with: () => ({
+          normalize: R.identity,
+          select: 'SELECT `starts` FROM `start`',
+          join: 'JOIN `start` ON `start`.`id` IS NOT NULL',
+          where: ' AND `start`.`deleted` IS NULL'
+        }),
+        ends_with: () => ({
+          normalize: R.identity,
+          select: '`ends` FROM `ending`',
+          join: 'JOIN `ending` ON `ending`.`id` IS NOT NULL',
+          where: 'AND `ending`.`deleted` IS NULL'
+        })
+      }
+
+      const params = {
+        'starts_with': 'asdf',
+        'ends_with': 'qwer'
+      }
+
+      const expected = {
+        select: 'SELECT `starts` FROM `start`, `ends` FROM `ending`',
+        join: 'JOIN `start` ON `start`.`id` IS NOT NULL JOIN `ending` ON `ending`.`id` IS NOT NULL',
+        where: ' AND `start`.`deleted` IS NULL AND `ending`.`deleted` IS NULL'
+      }
+
+      const results = Search.getClauses(map, params)
+
+      expect(results).to.eql(expected)
+
+      done()
+
+    })
+
+    it('should merge clauses and remove duplicate join', (done) => {
+
+      const map = {
+        starts_with: () => ({
+          normalize: R.identity,
+          select: 'SELECT `starts` FROM `start`',
+          join: 'JOIN `start` ON `start`.`id` IS NOT NULL',
+          where: ' AND `start`.`deleted` IS NULL'
+        }),
+        ends_with: () => ({
+          normalize: R.identity,
+          select: '`ends` FROM `ending`',
+          join: 'JOIN `start` ON `start`.`id` IS NOT NULL',
+          where: 'AND `ending`.`deleted` IS NULL'
+        })
+      }
+
+      const params = {
+        'starts_with': 'asdf',
+        'ends_with': 'qwer'
+      }
+
+      const expected = {
+        select: 'SELECT `starts` FROM `start`, `ends` FROM `ending`',
+        join: 'JOIN `start` ON `start`.`id` IS NOT NULL ',
+        where: ' AND `start`.`deleted` IS NULL AND `ending`.`deleted` IS NULL'
+      }
+
+      const results = Search.getClauses(map, params)
+
+      expect(results).to.eql(expected)
+
+      done()
+
+    })
+
+  })
+
+  describe('::getCountSql', (done) => {
+
+    it('should build a query to grab the count', (done) => {
+
+      const sql = 'Query'
+
+      const expected = `
+    SELECT COUNT(*) AS \`count\`
+    FROM (Query) AS \`temp\`
+`
+
+      const results = Search.getCountSql(sql)
+
+      expect(results).to.eql(expected)
+
+      done()
+    })
+
+  })
+
+
+})

--- a/test/lib/search.spec.js
+++ b/test/lib/search.spec.js
@@ -11,7 +11,10 @@ describe('lib/search.js', () => {
 
     it('should return default pagination params', (done) => {
 
-      const test = {}
+      const test = {
+        page: undefined,
+        limit: undefined
+      }
 
       const results = Search.parseParams({})(test)
 
@@ -77,9 +80,9 @@ describe('lib/search.js', () => {
       }
 
       const map = {
-        starts_with: {
+        starts_with: () => ({
           validation: []
-        }
+        })
       }
 
       const results = Search.parseParams(map)(test)
@@ -104,10 +107,10 @@ describe('lib/search.js', () => {
       }
 
       const map = {
-        starts_with: {
+        starts_with: () => ({
           validation: [],
           normalize: R.toUpper
-        }
+        })
       }
 
       const results = Search.parseParams(map)(test)


### PR DESCRIPTION
Search function for Model.

takes an object that maps parameters to sql clauses, which is used in conjunction with parameter-value object to build an sql query for searching. Currently uses a regex to identify join clauses and eliminate duplicates.

Further Refactoring: Looking at changing structure of join clauses in mapping object to include alias for each join clause. Would make regex unnecessary and allow full support for sub-selects in join clauses.