### PR TITLE
return non-normalized params [Delivers #130140959]

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -180,7 +180,7 @@ const search = R.curry((sql_factory, map, conn, params) => {
   const sql_count = Search.getCountSql(sql)
 
   return Bluebird.props({
-    params: _params,
+    params: params,
     count : query.select(conn, sql_count, [], false).get(0).get('count'),
     rows  : query.select(conn, sql_paginated, [], false)
   })

--- a/lib/model.js
+++ b/lib/model.js
@@ -169,7 +169,9 @@ const save = R.curry(
 
 const search = R.curry((sql_factory, map, conn, params) => {
 
-  const _params = Search.parseParams(map)(params)
+  params = Search.parseParams(map)(params)
+
+  const _params = Search.normalizeParams(map)(params)
 
   const clauses = Search.getClauses(map, _params)
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -34,15 +34,14 @@ parseParams = (map) => R.compose(
       _parsePaginationParams
     ]
   ),
-  _normalizeParams(map),
   _sanitizeParams
 )
 
 // _sanitizeParamss:: Object -> Object
 _sanitizeParams = R.pickBy(R.compose(R.not,R.isNil))
 
-// _normalizeParams:: Object -> Object - Object
-_normalizeParams = (map) => R.mapObjIndexed(
+// normalizeParams:: Object -> Object - Object
+normalizeParams = (map) => R.mapObjIndexed(
   (val, key) => {
 
     let _normalize = R.identity
@@ -129,6 +128,7 @@ const getCountSql = (sql) => {
 
 module.exports = {
   parseParams: parseParams,
+  normalizeParams: normalizeParams,
   addPagination: addPagination,
   getClauses: getClauses,
   getCountSql: getCountSql

--- a/test/lib/search.spec.js
+++ b/test/lib/search.spec.js
@@ -12,7 +12,7 @@ describe('lib/search.js', () => {
     it('should return default pagination params', (done) => {
 
       const test = {
-        page: undefined,
+        page : undefined,
         limit: undefined
       }
 
@@ -20,8 +20,8 @@ describe('lib/search.js', () => {
 
       const expected = {
         offset: 0,
-        limit: 16,
-        page: 1
+        limit : 16,
+        page  : 1
       }
 
       expect(results).to.eql(expected)
@@ -33,7 +33,7 @@ describe('lib/search.js', () => {
     it('should return offset of 24', (done) => {
 
       const test = {
-        page: 3,
+        page : 3,
         limit: 12
       }
 
@@ -41,8 +41,8 @@ describe('lib/search.js', () => {
 
       const expected = {
         offset: 24,
-        limit: 12,
-        page: 3
+        limit : 12,
+        page  : 3
       }
 
       expect(results).to.eql(expected)
@@ -63,8 +63,8 @@ describe('lib/search.js', () => {
 
       const expected = {
         offset: 0,
-        limit: 16,
-        page: 1
+        limit : 16,
+        page  : 1
       }
 
       expect(results).to.eql(expected)
@@ -88,9 +88,9 @@ describe('lib/search.js', () => {
       const results = Search.parseParams(map)(test)
 
       const expected = {
-        offset: 0,
-        limit: 16,
-        page: 1,
+        offset     : 0,
+        limit      : 16,
+        page       : 1,
         starts_with: 'asdf'
       }
 
@@ -99,6 +99,10 @@ describe('lib/search.js', () => {
       done()
 
     })
+
+  })
+
+  describe('::normalizeParams', () => {
 
     it('should return with normalized starts_with param', (done) => {
 
@@ -113,12 +117,9 @@ describe('lib/search.js', () => {
         })
       }
 
-      const results = Search.parseParams(map)(test)
+      const results = Search.normalizeParams(map)(test)
 
       const expected = {
-        offset: 0,
-        limit: 16,
-        page: 1,
         starts_with: 'ASDF'
       }
 


### PR DESCRIPTION
Matching Lib on api needs non-normalized params returned (starts_with was returning with '%' appended; messes up matching algorithm)