### PR TITLE
Update getTimestamp function and tests

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -21,18 +21,11 @@ const idMatch = _.curry((id, obj) => id + '' === obj.id + '');
 
 const dateIsUnix = _.compose(_.equals(0), _.modulo(_.__, 1));
 
-const dateIsMs = _.compose(
-  _.ifElse(
-    _.lt(LARGEST_UNIX_TIMESTAMP),
-    _.T,
-    _.F
-  )
-, parseInt
-)
 
+// dateInMs :: Int -> Bool
+const dateIsMs = (num) => (parseInt(num) > LARGEST_UNIX_TIMESTAMP)
 
 const momentFromString = (date) => moment(new Date(date));
-
 
 const momentFromDate = _.cond([
   [ _.isNil,         moment ]

--- a/lib/query.js
+++ b/lib/query.js
@@ -9,9 +9,9 @@ const jsonparse       = require('./json-parse');
 const nestify         = require('./nestify');
 const nullify         = require('./nullify-empty');
 
+
 const TIMESTAMP_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
-const LARGEST_UNIX_TIMESTAMP = 2147483647;
 
 const bindError = _.curry((fn, sql, params) => fn.bind(null, sql, params));
 
@@ -22,15 +22,12 @@ const idMatch = _.curry((id, obj) => id + '' === obj.id + '');
 const dateIsUnix = _.compose(_.equals(0), _.modulo(_.__, 1));
 
 
-// dateInMs :: Int -> Bool
-const dateIsMs = (num) => (parseInt(num) > LARGEST_UNIX_TIMESTAMP)
-
 const momentFromString = (date) => moment(new Date(date));
+
 
 const momentFromDate = _.cond([
   [ _.isNil,         moment ]
 , [ moment.isMoment, _.identity ]
-, [ dateIsMs,        (ms) => moment(parseInt(ms)) ]
 , [ dateIsUnix,      moment.unix ]
 , [ _.T,             momentFromString ]
 ]);
@@ -251,7 +248,7 @@ const getOneById = _.curry((db, sql, id, no_cache = false) => {
 });
 
 
-// getTimestamp ::  (any, string) -> string | null | Error
+// getTimestamp ::  any -> string | null | Error
 const getTimestamp = (date) => {
 
   if (date == null) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -248,9 +248,16 @@ const getOneById = _.curry((db, sql, id, no_cache = false) => {
 });
 
 
+// getTimestamp ::  any -> string | null
 const getTimestamp = (date) => {
+
   const m = momentFromDate(date);
-  return m.format(TIMESTAMP_FORMAT);
+
+  if (m.isValid()) {
+    return m.format(TIMESTAMP_FORMAT);
+  }
+
+  return null
 };
 
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -259,7 +259,7 @@ const getOneById = _.curry((db, sql, id, no_cache = false) => {
 });
 
 
-// getTimestamp ::  any -> string | null
+// getTimestamp ::  any -> string | null | Error
 const getTimestamp = (date) => {
 
   const m = momentFromDate(date);

--- a/lib/query.js
+++ b/lib/query.js
@@ -253,11 +253,16 @@ const getTimestamp = (date) => {
 
   const m = momentFromDate(date);
 
+  if (date == null) {
+    return null
+  }
+
   if (m.isValid()) {
     return m.format(TIMESTAMP_FORMAT);
   }
 
-  return null
+  throw new Error('Invalid Input')
+
 };
 
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -12,6 +12,7 @@ const nullify         = require('./nullify-empty');
 
 const TIMESTAMP_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
+const LARGEST_UNIX_TIMESTAMP = 2147483647;
 
 const bindError = _.curry((fn, sql, params) => fn.bind(null, sql, params));
 
@@ -21,6 +22,15 @@ const idMatch = _.curry((id, obj) => id + '' === obj.id + '');
 
 const dateIsUnix = _.compose(_.equals(0), _.modulo(_.__, 1));
 
+const dateIsMs = _.compose(
+  _.ifElse(
+    _.lt(LARGEST_UNIX_TIMESTAMP),
+    _.T,
+    _.F
+  )
+, parseInt
+)
+
 
 const momentFromString = (date) => moment(new Date(date));
 
@@ -28,6 +38,7 @@ const momentFromString = (date) => moment(new Date(date));
 const momentFromDate = _.cond([
   [ _.isNil,         moment ]
 , [ moment.isMoment, _.identity ]
+, [ dateIsMs,        (ms) => moment(parseInt(ms)) ]
 , [ dateIsUnix,      moment.unix ]
 , [ _.T,             momentFromString ]
 ]);

--- a/lib/query.js
+++ b/lib/query.js
@@ -9,7 +9,6 @@ const jsonparse       = require('./json-parse');
 const nestify         = require('./nestify');
 const nullify         = require('./nullify-empty');
 
-
 const TIMESTAMP_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
 const LARGEST_UNIX_TIMESTAMP = 2147483647;
@@ -259,14 +258,14 @@ const getOneById = _.curry((db, sql, id, no_cache = false) => {
 });
 
 
-// getTimestamp ::  any -> string | null | Error
+// getTimestamp ::  (any, string) -> string | null | Error
 const getTimestamp = (date) => {
 
-  const m = momentFromDate(date);
-
   if (date == null) {
-    return null
+    return null;
   }
+
+  const m = momentFromDate(date);
 
   if (m.isValid()) {
     return m.format(TIMESTAMP_FORMAT);

--- a/test/lib/query.spec.js
+++ b/test/lib/query.spec.js
@@ -1,5 +1,6 @@
 /*eslint-env node, mocha */
 const R           = require('ramda');
+const moment      = require('moment');
 const { expect }  = require('chai');
 const { inspect } = require('util');
 const sinon       = require('sinon');
@@ -122,7 +123,7 @@ describe('Pimp My Sql :: Query', function() {
 
       const surround = (char, x) => char + x + char;
       const surround_all = (char, x) => x.map(surround.bind(null, char));
-        
+
 
       testLib.escapeId = x => surround('`', x);
       testLib.escape = x =>
@@ -291,6 +292,82 @@ describe('Pimp My Sql :: Query', function() {
       })
 
     })
+  })
+
+  describe('::getTimestamp', () => {
+    it('should return a proper date and time for a unix timestamp', () => {
+
+      const input = 1515188138
+      const result = Query.getTimestamp(input)
+
+      expect(result).to.eql('2018-01-05 13:35:38');
+
+    })
+
+    it('should return a proper date and time for a string of a unix timestamp', () => {
+
+      const input = '1515188138'
+      const result = Query.getTimestamp(input)
+
+      expect(result).to.eql('2018-01-05 13:35:38');
+
+    })
+
+    it('should return a proper date and time for a moment value', () => {
+
+      const input = moment('2017-07-07 13:07:07')
+      const result = Query.getTimestamp(input)
+
+      expect(result).to.eql('2017-07-07 13:07:07');
+
+    })
+
+    it('should return a proper date and time for a formatted date', () => {
+
+      const input = '12/31/2017'
+      const result = Query.getTimestamp(input)
+
+      expect(result).to.eql('2017-12-31 00:00:00');
+
+    })
+
+    it('should return a proper date and time for a typed out date', () => {
+
+      const input = 'January 20, 2017'
+      const result = Query.getTimestamp(input)
+
+      expect(result).to.eql('2017-01-20 00:00:00');
+
+    })
+
+    it('should return null for an incorrectly typed out date', () => {
+
+      const input = 'June 17th, 2017'
+      const result = Query.getTimestamp(input)
+
+      expect(result).to.eql(null);
+
+    })
+
+
+    it('should return null for null input', () => {
+
+      const nullInput = null
+      const result = Query.getTimestamp(nullInput)
+
+      expect(result).to.eql(null);
+
+    })
+
+    it('should return null for garbage input', () => {
+
+      const input = 'thisisgarbateinput'
+      const result = Query.getTimestamp(input)
+
+      expect(result).to.eql(null);
+
+    })
+
   })
 
 });

--- a/test/lib/query.spec.js
+++ b/test/lib/query.spec.js
@@ -297,7 +297,7 @@ describe('Pimp My Sql :: Query', function() {
   })
 
   describe('::getTimestamp', () => {
-    it('should return a proper date and time for a unix timestamp', () => {
+    it('should return a proper date and time for a unix timestamp in seconds', () => {
 
       const input = 1515188138
       const result = Query.getTimestamp(input)
@@ -308,7 +308,7 @@ describe('Pimp My Sql :: Query', function() {
 
     })
 
-    it('should return a proper date and time for a string of a unix timestamp', () => {
+    it('should return a proper date and time for a string of a unix timestamp in seconds', () => {
 
       const input = '1515188138'
       const result = Query.getTimestamp(input)
@@ -319,23 +319,23 @@ describe('Pimp My Sql :: Query', function() {
 
     })
 
-    it('should return a proper date and time for a unix timestamp in ms', () => {
+    it('should return a improper date and time for a unix timestamp in ms', () => {
 
       const input = 1515188138000
       const result = Query.getTimestamp(input)
 
-      const expected = moment(parseInt(input)).format(TIMESTAMP_FORMAT)
+      const expected = moment.unix(input).format(TIMESTAMP_FORMAT)
 
       expect(result).to.eql(expected);
 
     })
 
-    it('should return a proper date and time for a string of a unix timestamp in ms', () => {
+    it('should return a improper date and time for a string of a unix timestamp in ms', () => {
 
       const input = '1515188138000'
       const result = Query.getTimestamp(input)
 
-      const expected = moment(parseInt(input)).format(TIMESTAMP_FORMAT)
+      const expected = moment.unix(input).format(TIMESTAMP_FORMAT)
 
       expect(result).to.eql(expected);
 

--- a/test/lib/query.spec.js
+++ b/test/lib/query.spec.js
@@ -352,9 +352,13 @@ describe('Pimp My Sql :: Query', function() {
     it('should return null for an incorrectly typed out date', () => {
 
       const input = 'June 17th, 2017'
-      const result = Query.getTimestamp(input)
+      const error = new Error('Invalid Input')
 
-      expect(result).to.eql(null);
+      try {
+        Query.getTimestamp(input)
+      } catch (err) {
+        expect(err).to.eql(error)
+      }
 
     })
 
@@ -368,12 +372,16 @@ describe('Pimp My Sql :: Query', function() {
 
     })
 
-    it('should return null for garbage input', () => {
+    it('should throw an error for garbage input', () => {
 
       const input = 'thisisgarbageinput'
-      const result = Query.getTimestamp(input)
+      const error = new Error('Invalid Input')
 
-      expect(result).to.eql(null);
+      try {
+        Query.getTimestamp(input)
+      } catch (err) {
+        expect(err).to.eql(error)
+      }
 
     })
 

--- a/test/lib/query.spec.js
+++ b/test/lib/query.spec.js
@@ -6,6 +6,8 @@ const { inspect } = require('util');
 const sinon       = require('sinon');
 const Query       = require('../../lib/query');
 
+const TIMESTAMP_FORMAT = 'YYYY-MM-DD HH:mm:ss';
+
 let testLib = null;
 
 describe('Pimp My Sql :: Query', function() {
@@ -300,7 +302,9 @@ describe('Pimp My Sql :: Query', function() {
       const input = 1515188138
       const result = Query.getTimestamp(input)
 
-      expect(result).to.eql('2018-01-05 13:35:38');
+      const expected = moment.unix(input).format(TIMESTAMP_FORMAT)
+
+      expect(result).to.eql(expected);
 
     })
 
@@ -309,7 +313,9 @@ describe('Pimp My Sql :: Query', function() {
       const input = '1515188138'
       const result = Query.getTimestamp(input)
 
-      expect(result).to.eql('2018-01-05 13:35:38');
+      const expected = moment.unix(input).format(TIMESTAMP_FORMAT)
+
+      expect(result).to.eql(expected);
 
     })
 
@@ -318,7 +324,9 @@ describe('Pimp My Sql :: Query', function() {
       const input = 1515188138000
       const result = Query.getTimestamp(input)
 
-      expect(result).to.eql('2018-01-05 13:35:38');
+      const expected = moment(parseInt(input)).format(TIMESTAMP_FORMAT)
+
+      expect(result).to.eql(expected);
 
     })
 
@@ -327,7 +335,9 @@ describe('Pimp My Sql :: Query', function() {
       const input = '1515188138000'
       const result = Query.getTimestamp(input)
 
-      expect(result).to.eql('2018-01-05 13:35:38');
+      const expected = moment(parseInt(input)).format(TIMESTAMP_FORMAT)
+
+      expect(result).to.eql(expected);
 
     })
 
@@ -363,7 +373,9 @@ describe('Pimp My Sql :: Query', function() {
       const input = ''
       const result = Query.getTimestamp(input)
 
-      expect(result).to.eql('1969-12-31 16:00:00');
+      const expected = moment.unix(input).format(TIMESTAMP_FORMAT)
+
+      expect(result).to.eql(expected);
 
     })
 

--- a/test/lib/query.spec.js
+++ b/test/lib/query.spec.js
@@ -340,6 +340,15 @@ describe('Pimp My Sql :: Query', function() {
 
     })
 
+    it('should return 1969-12-31 16:00:00 for an empty string', () => {
+
+      const input = ''
+      const result = Query.getTimestamp(input)
+
+      expect(result).to.eql('1969-12-31 16:00:00');
+
+    })
+
     it('should return null for an incorrectly typed out date', () => {
 
       const input = 'June 17th, 2017'
@@ -361,7 +370,7 @@ describe('Pimp My Sql :: Query', function() {
 
     it('should return null for garbage input', () => {
 
-      const input = 'thisisgarbateinput'
+      const input = 'thisisgarbageinput'
       const result = Query.getTimestamp(input)
 
       expect(result).to.eql(null);

--- a/test/lib/query.spec.js
+++ b/test/lib/query.spec.js
@@ -313,6 +313,24 @@ describe('Pimp My Sql :: Query', function() {
 
     })
 
+    it('should return a proper date and time for a unix timestamp in ms', () => {
+
+      const input = 1515188138000
+      const result = Query.getTimestamp(input)
+
+      expect(result).to.eql('2018-01-05 13:35:38');
+
+    })
+
+    it('should return a proper date and time for a string of a unix timestamp in ms', () => {
+
+      const input = '1515188138000'
+      const result = Query.getTimestamp(input)
+
+      expect(result).to.eql('2018-01-05 13:35:38');
+
+    })
+
     it('should return a proper date and time for a moment value', () => {
 
       const input = moment('2017-07-07 13:07:07')
@@ -361,7 +379,6 @@ describe('Pimp My Sql :: Query', function() {
       }
 
     })
-
 
     it('should return null for null input', () => {
 


### PR DESCRIPTION
- Fixes `getTimestamp` function to accommodate for `null` and garbage input strings. 
- Adds specs for testing `getTimestamp` function